### PR TITLE
Fix GrumPHP dependency and setting file format

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "filp/whoops": "^2.5",
     "franzl/whoops-middleware": "^1.1",
     "laminas/laminas-component-installer": "^2.1",
-    "phpro/grumphp": "^0.17.0",
+    "phpro/grumphp": "^0.17.0 || ^1.0",
     "phpstan/phpstan": "^0.11.5",
     "phpunit/phpunit": "^8.0",
     "roave/security-advisories": "dev-master",

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -1,6 +1,6 @@
-parameters:
-    git_dir: .
-    bin_dir: vendor/bin
+grumphp:
+    hooks_dir: .
+    hooks_preset: local
     tasks:
         composer_script:
             script: check-all


### PR DESCRIPTION
# Changed log

- To fix following message during `composer install` command running, adding the `^1.0` `GrumPHP` version.

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - phpro/grumphp[v0.17.0, ..., v0.17.2] require composer-plugin-api ~1.0 -> found composer-plugin-api[2.0.0] but it does not match the constraint.
    - Root composer.json requires phpro/grumphp ^0.17.0 -> satisfiable by phpro/grumphp[v0.17.0, v0.17.1, v0.17.2].

You are using Composer 2, which some of your plugins seem to be incompatible with. Make sure you update your plugins or report a plugin-issue to ask them to support Composer 2.

```

- Using the [grumphp.yml](https://github.com/antidot-framework/antidot-framework/blob/master/grumphp.yml) file to replace origin file and it will fix following error message:

```
.......
83 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
PHP Fatal error:  Uncaught GrumPHP\Exception\DeprecatedException: Direct configuration of parameter tasks is not allowed anymore.
Please rename the `parameters` section in your grumphp.yaml file to `grumphp`.
More info: https://github.com/phpro/grumphp/releases/tag/v0.19.0

 in /data/getting-started-app/vendor/phpro/grumphp/src/Exception/DeprecatedException.php:11
Stack trace:
#0 /data/getting-started-app/vendor/phpro/grumphp/src/Configuration/GrumPHPExtension.php(40): GrumPHP\Exception\DeprecatedException::directParameterConfiguration()
#1 /data/getting-started-app/vendor/phpro/grumphp/src/Configuration/GrumPHPExtension.php(17): GrumPHP\Configuration\GrumPHPExtension->loadInternal()
#2 /data/getting-started-app/vendor/symfony/dependency-injection/Compiler/MergeExtensionConfigurationPass.php(76): GrumPHP\Configuration\GrumPHPExtension->load()
#3 /data/getting-started-app/vendor/symfony/dependency-injection/Compiler/Compiler.php(91): Symfony\Component\DependencyInjection\Compiler\MergeExtensionConfigurationPass->process()
#4 /d in /data/getting-started-app/vendor/phpro/grumphp/src/Exception/DeprecatedException.php on line 11
GrumPHP can not sniff your commits! (invalid-exit-code)
PHP Fatal error:  Uncaught GrumPHP\Exception\DeprecatedException: Direct configuration of parameter tasks is not allowed anymore.
Please rename the `parameters` section in your grumphp.yaml file to `grumphp`.
More info: https://github.com/phpro/grumphp/releases/tag/v0.19.0

 in /data/getting-started-app/vendor/phpro/grumphp/src/Exception/DeprecatedException.php:11
Stack trace:
#0 /data/getting-started-app/vendor/phpro/grumphp/src/Configuration/GrumPHPExtension.php(40): GrumPHP\Exception\DeprecatedException::directParameterConfiguration()
#1 /data/getting-started-app/vendor/phpro/grumphp/src/Configuration/GrumPHPExtension.php(17): GrumPHP\Configuration\GrumPHPExtension->loadInternal()
#2 /data/getting-started-app/vendor/symfony/dependency-injection/Compiler/MergeExtensionConfigurationPass.php(76): GrumPHP\Configuration\GrumPHPExtension->load()
#3 /data/getting-started-app/vendor/symfony/dependency-injection/Compiler/Compiler.php(91): Symfony\Component\DependencyInjection\Compiler\MergeExtensionConfigurationPass->process()
#4 /d in /data/getting-started-app/vendor/phpro/grumphp/src/Exception/DeprecatedException.php on line 11

```